### PR TITLE
meson: Allow host binaries for cross-compiles

### DIFF
--- a/_resources/port1.0/group/meson-1.0.tcl
+++ b/_resources/port1.0/group/meson-1.0.tcl
@@ -33,11 +33,11 @@ default destroot.post_args  ""
 namespace eval meson { }
 
 proc meson::get_post_args {} {
-    global configure.dir build_dir muniversal.current_arch
+    global configure.build_arch configure.dir build_dir muniversal.current_arch
     if {[info exists muniversal.current_arch]} {
         return "${configure.dir} ${build_dir}-${muniversal.current_arch} --cross-file=${muniversal.current_arch}-darwin"
     } else {
-        return "${configure.dir} ${build_dir}"
+        return "${configure.dir} ${build_dir} --cross-file=${configure.build_arch}-darwin"
     }
 }
 

--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -91,6 +91,12 @@ patchfiles-append   patch-meson-search-prefix-for-cross-files.diff
 post-patch {
     reinplace "s|@@PREFIX@@|${prefix}|g" ${worksrcpath}/data/shell-completions/bash/meson \
                                          ${worksrcpath}/mesonbuild/coredata.py
+
+    # Revert https://github.com/mesonbuild/meson/commit/f5bd325
+    reinplace "s|allow_default_for_cross=False|allow_default_for_cross=True|g" \
+        ${worksrcpath}/mesonbuild/cmake/executor.py \
+        ${worksrcpath}/mesonbuild/dependencies/configtool.py \
+        ${worksrcpath}/mesonbuild/dependencies/pkgconfig.py
 }
 
 post-destroot {
@@ -101,11 +107,6 @@ post-destroot {
     # install our MacPorts cross files
     xinstall -m 755 -d ${destroot}${prefix}/share/meson/
     copy ${filespath}/cross ${destroot}${prefix}/share/meson/
-
-    fs-traverse f ${destroot}${prefix}/share/meson/cross/ {
-        if {![file isdirectory ${f}]} {
-            reinplace "s|@@PREFIX@@|${prefix}|g" ${f}
-        }
     }
 
     # install shell completion files

--- a/devel/meson/files/cross/arm64-darwin
+++ b/devel/meson/files/cross/arm64-darwin
@@ -3,7 +3,3 @@ system = 'darwin'
 cpu_family = 'aarch64'
 cpu = 'arm64'
 endian = 'little'
-
-[binaries]
-pkgconfig = '@@PREFIX@@/bin/pkg-config'
-cmake = '@@PREFIX@@/bin/cmake'

--- a/devel/meson/files/cross/i386-darwin
+++ b/devel/meson/files/cross/i386-darwin
@@ -3,7 +3,3 @@ system = 'darwin'
 cpu_family = 'x86'
 cpu = 'i386'
 endian = 'little'
-
-[binaries]
-pkgconfig = '@@PREFIX@@/bin/pkg-config'
-cmake = '@@PREFIX@@/bin/cmake'

--- a/devel/meson/files/cross/ppc-darwin
+++ b/devel/meson/files/cross/ppc-darwin
@@ -3,7 +3,3 @@ system = 'darwin'
 cpu_family = 'ppc'
 cpu = 'ppc'
 endian = 'big'
-
-[binaries]
-pkgconfig = '@@PREFIX@@/bin/pkg-config'
-cmake = '@@PREFIX@@/bin/cmake'

--- a/devel/meson/files/cross/ppc64-darwin
+++ b/devel/meson/files/cross/ppc64-darwin
@@ -3,7 +3,3 @@ system = 'darwin'
 cpu_family = 'ppc64'
 cpu = 'ppc64'
 endian = 'big'
-
-[binaries]
-pkgconfig = '@@PREFIX@@/bin/pkg-config'
-cmake = '@@PREFIX@@/bin/cmake'

--- a/devel/meson/files/cross/x86_64-darwin
+++ b/devel/meson/files/cross/x86_64-darwin
@@ -3,7 +3,3 @@ system = 'darwin'
 cpu_family = 'x86_64'
 cpu = 'x86_64'
 endian = 'little'
-
-[binaries]
-pkgconfig = '@@PREFIX@@/bin/pkg-config'
-cmake = '@@PREFIX@@/bin/cmake'


### PR DESCRIPTION
This change allows `meson` to find installed binary files and should also unblock the more standard env flags.

I'd proposed this fix to macports originally but they'd instead gone with the current method of needing to manually setting each binary manually. The restores `meson` behavior prior to the upstream change that _fixed_ Linux compilations but broken macOS compilations.